### PR TITLE
add detection routine for data in CESR-T domain

### DIFF
--- a/tsp-cesr/Cargo.toml
+++ b/tsp-cesr/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 
 [features]
 strict = [ ]
+cesr-t = ["dep:base64ct"]
+
+[dependencies]
+base64ct = { version = "1.6.0", optional = true, features = [ ] }
 
 [dev-dependencies]
 base64ct = { version = "1.6.0", features = ["alloc"] }

--- a/tsp-cesr/src/detect.rs
+++ b/tsp-cesr/src/detect.rs
@@ -1,0 +1,28 @@
+use base64ct::{Base64Url, Encoding};
+
+pub fn to_binary(data: &mut [u8]) -> Option<&[u8]> {
+    let first_byte = data.first()?;
+
+    match first_byte >> 5 {
+        0b001 => Base64Url::decode_in_place(data).ok(), // CESR in the T domain
+        0b111 => Some(data),                            // CESR in the B domain
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::to_binary;
+    use base64ct::{Base64Url, Encoding};
+
+    #[test]
+    fn test_binary() {
+        let base64 = *b"-FAB";
+        let binary = Base64Url::decode_vec(std::str::from_utf8(&base64).unwrap()).unwrap();
+        assert_eq!(to_binary(&mut binary.clone()).unwrap(), binary);
+        assert_eq!(to_binary(&mut base64.clone()).unwrap(), binary);
+
+        assert!(to_binary(b"AAAA").is_none());
+        assert!(to_binary([0, 0, 0]).is_none());
+    }
+}

--- a/tsp-cesr/src/lib.rs
+++ b/tsp-cesr/src/lib.rs
@@ -1,4 +1,6 @@
 mod decode;
+#[cfg(feature = "cesr-t")]
+mod detect;
 mod encode;
 
 pub use decode::{
@@ -7,6 +9,9 @@ pub use decode::{
 pub use encode::{
     encode_count, encode_fixed_data, encode_genus, encode_indexed_data, encode_variable_data,
 };
+
+#[cfg(feature = "cesr-t")]
+pub use detect::to_binary;
 
 /// Safely restrict value to a certain number of bits
 fn bits(value: impl Into<u32>, bits: u8) -> u32 {


### PR DESCRIPTION
This is optional, under control of the `cesr-t` flag.