### PR TITLE
high level interface for CESR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "generic-array"
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "opaque-debug"
@@ -554,24 +554,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -616,9 +616,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -686,9 +686,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ dependencies = [
  "ed25519-dalek",
  "hpke",
  "rand",
+ "tsp-cesr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ hpke = { git = "https://github.com/marlonbaeten/rust-hpke", branch = "keys-by-re
 crypto_box = { version = "0.9", features = ["alloc", "seal", "chacha20"] }
 rand = "0.8"
 ed25519-dalek = { version = "2", features = [ "rand_core", "pkcs8" ] }
+base64ct = { version = "1.6.0", features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 rust-version = "1.75"
 
 [workspace.dependencies]
-hpke = { git = "https://github.com/marlonbaeten/rust-hpke", branch = "keys-by-reference" }
+hpke = { git = "https://github.com/marlonbaeten/rust-hpke", branch = "keys-by-reference", features = ["alloc"] }
 crypto_box = { version = "0.9", features = ["alloc", "seal", "chacha20"] }
 rand = "0.8"
 ed25519-dalek = { version = "2", features = [ "rand_core", "pkcs8" ] }

--- a/tsp-cesr/Cargo.toml
+++ b/tsp-cesr/Cargo.toml
@@ -14,6 +14,7 @@ default = ["std"]
 std = [ ]
 strict = [ ]
 alloc = [ ]
+demo = ["alloc"]
 
 [dependencies]
 base64ct = { workspace = true, optional = true }

--- a/tsp-cesr/Cargo.toml
+++ b/tsp-cesr/Cargo.toml
@@ -9,11 +9,13 @@ publish.workspace = true
 rust-version.workspace = true
 
 [features]
-strict = [ ]
 cesr-t = ["dep:base64ct"]
+default = ["std"]
+std = [ ]
+strict = [ ]
 
 [dependencies]
-base64ct = { version = "1.6.0", optional = true, features = [ ] }
+base64ct = { workspace = true, optional = true }
 
 [dev-dependencies]
-base64ct = { version = "1.6.0", features = ["alloc"] }
+base64ct = { workspace = true }

--- a/tsp-cesr/Cargo.toml
+++ b/tsp-cesr/Cargo.toml
@@ -13,6 +13,7 @@ cesr-t = ["dep:base64ct"]
 default = ["std"]
 std = [ ]
 strict = [ ]
+alloc = [ ]
 
 [dependencies]
 base64ct = { workspace = true, optional = true }

--- a/tsp-cesr/src/decode.rs
+++ b/tsp-cesr/src/decode.rs
@@ -62,6 +62,7 @@ pub fn decode_variable_data<'a>(identifier: u32, stream: &mut &'a [u8]) -> Optio
 }
 
 /// Decode indexed data with a known identifier
+#[allow(dead_code)]
 pub fn decode_indexed_data<'a, const N: usize>(
     identifier: u32,
     stream: &mut &'a [u8],
@@ -100,6 +101,7 @@ pub fn decode_indexed_data<'a, const N: usize>(
 }
 
 /// Decode a frame with known identifier and size
+#[allow(dead_code)]
 pub fn decode_count(identifier: u16, stream: &mut &[u8]) -> Option<u16> {
     let word = extract_triplet(stream.get(0..=2)?.try_into().unwrap());
     let index = word & mask(12);
@@ -115,6 +117,7 @@ pub fn decode_count(identifier: u16, stream: &mut &[u8]) -> Option<u16> {
 }
 
 /// Decode a genus with known identifier and version
+#[allow(dead_code)]
 pub fn decode_genus(
     genus: [u8; 3],
     (major, minor, patch): (u8, u8, u8),

--- a/tsp-cesr/src/encode.rs
+++ b/tsp-cesr/src/encode.rs
@@ -21,6 +21,7 @@ pub fn encode_fixed_data(
 }
 
 /// Encode indexed fixed size data with a known identifier
+#[allow(dead_code)]
 pub fn encode_indexed_data(
     identifier: u32,
     index: u16,
@@ -67,6 +68,7 @@ pub fn encode_variable_data(
 }
 
 /// Encode a frame with known identifier and count code
+#[allow(dead_code)]
 pub fn encode_count(identifier: u16, count: u16, stream: &mut impl for<'a> Extend<&'a u8>) {
     let word = DASH << 18 | bits(identifier, 6) << 12 | bits(count, 12);
 
@@ -74,6 +76,7 @@ pub fn encode_count(identifier: u16, count: u16, stream: &mut impl for<'a> Exten
 }
 
 /// Encode a genus with known identifier and version
+#[allow(dead_code)]
 pub fn encode_genus(
     genus: [u8; 3],
     (major, minor, patch): (u8, u8, u8),

--- a/tsp-cesr/src/error.rs
+++ b/tsp-cesr/src/error.rs
@@ -6,7 +6,10 @@ pub enum EncodeError {
 
 /// An error type to indicate something went wrong with decoding
 #[derive(Clone, Copy, Debug)]
-pub struct DecodeError;
+pub enum DecodeError {
+    UnexpectedData,
+    TrailingGarbage,
+}
 
 #[cfg(feature = "std")]
 impl std::fmt::Display for EncodeError {

--- a/tsp-cesr/src/error.rs
+++ b/tsp-cesr/src/error.rs
@@ -9,6 +9,8 @@ pub enum EncodeError {
 pub enum DecodeError {
     UnexpectedData,
     TrailingGarbage,
+    SignatureError,
+    VidError,
 }
 
 #[cfg(feature = "std")]

--- a/tsp-cesr/src/error.rs
+++ b/tsp-cesr/src/error.rs
@@ -1,0 +1,29 @@
+/// An error type to indicate something went wrong with encoding
+#[derive(Clone, Copy, Debug)]
+pub enum EncodeError {
+    PayloadTooLarge,
+}
+
+/// An error type to indicate something went wrong with decoding
+#[derive(Clone, Copy, Debug)]
+pub struct DecodeError;
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for EncodeError {}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeError {}

--- a/tsp-cesr/src/lib.rs
+++ b/tsp-cesr/src/lib.rs
@@ -3,7 +3,9 @@ mod decode;
 mod detect;
 mod encode;
 pub mod error;
-pub mod packet;
+mod packet;
+
+pub use packet::*;
 
 #[cfg(feature = "cesr-t")]
 pub use detect::to_binary;

--- a/tsp-cesr/src/lib.rs
+++ b/tsp-cesr/src/lib.rs
@@ -2,13 +2,8 @@ mod decode;
 #[cfg(feature = "cesr-t")]
 mod detect;
 mod encode;
-
-pub use decode::{
-    decode_count, decode_fixed_data, decode_genus, decode_indexed_data, decode_variable_data,
-};
-pub use encode::{
-    encode_count, encode_fixed_data, encode_genus, encode_indexed_data, encode_variable_data,
-};
+pub mod error;
+pub mod packet;
 
 #[cfg(feature = "cesr-t")]
 pub use detect::to_binary;
@@ -61,6 +56,8 @@ mod selector {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::decode::*;
+    use crate::encode::*;
 
     #[test]
     fn test_primitives() {

--- a/tsp-cesr/src/packet.rs
+++ b/tsp-cesr/src/packet.rs
@@ -1,0 +1,208 @@
+use crate::decode::{decode_fixed_data, decode_variable_data};
+use crate::encode::encode_fixed_data;
+use crate::error::{DecodeError, EncodeError};
+
+///TODO: add control messages
+/// A type to distinguish "normal" TSP messages from "control" messages
+#[repr(u32)]
+#[derive(Debug, Clone)]
+pub enum Payload<'a> {
+    /// A TSP message which consists only of a message which will be protected using HPKE
+    HpkeMessage(&'a [u8]),
+}
+
+/// Type representing a TSP Envelope
+#[derive(Debug, Clone)]
+pub struct Envelope<'a, Vid> {
+    pub sender: Vid,
+    pub receiver: Vid,
+    pub nonconfidential_header: Option<&'a [u8]>,
+    pub ciphertext: &'a [u8],
+}
+
+/// TODO: something more type safe
+pub type Signature<'a> = &'a [u8; 64];
+
+const TSP_PLAINTEXT: u32 = (b'B' - b'A') as u32;
+const TSP_CIPHERTEXT: u32 = (b'C' - b'A') as u32;
+const ED25519_SIGNATURE: u32 = (b'B' - b'A') as u32;
+
+const TSP_DEVELOPMENT_VID: u32 = 183236;
+
+/// Safely encode variable data, returning a soft error in case the size limit is exceeded
+fn checked_encode_variable_data(
+    identifier: u32,
+    payload: &[u8],
+    stream: &mut impl for<'a> Extend<&'a u8>,
+) -> Result<(), EncodeError> {
+    const DATA_LIMIT: usize = 50000000;
+
+    if payload.len() >= DATA_LIMIT {
+        return Err(EncodeError::PayloadTooLarge);
+    }
+
+    crate::encode::encode_variable_data(identifier, payload, stream);
+    Ok(())
+}
+
+/// Encode a TSP Payload into CESR for encryption
+/// TODO: add 'hops'
+pub fn encode_payload(
+    payload: Payload,
+    output: &mut impl for<'a> Extend<&'a u8>,
+) -> Result<(), EncodeError> {
+    let Payload::HpkeMessage(data) = payload;
+
+    checked_encode_variable_data(TSP_PLAINTEXT, data, output)
+}
+
+/// Decode a TSP Payload
+pub fn decode_payload(mut stream: &[u8]) -> Result<Payload, DecodeError> {
+    decode_variable_data(TSP_PLAINTEXT, &mut stream)
+        .map(Payload::HpkeMessage)
+        .ok_or(DecodeError)
+}
+
+/// Encode a encrypted TSP message plus Envelope into CESR
+/// TODO: replace types of sender/receiver with VID's (once we have that type)
+pub fn encode_envelope<'a, Vid: AsRef<[u8]>>(
+    envelope: Envelope<'a, Vid>,
+    output: &mut impl for<'b> Extend<&'b u8>,
+) -> Result<(), EncodeError> {
+    checked_encode_variable_data(TSP_DEVELOPMENT_VID, envelope.sender.as_ref(), output)?;
+    checked_encode_variable_data(TSP_DEVELOPMENT_VID, envelope.receiver.as_ref(), output)?;
+    if let Some(data) = envelope.nonconfidential_header {
+        checked_encode_variable_data(TSP_PLAINTEXT, data, output)?;
+    }
+    checked_encode_variable_data(TSP_CIPHERTEXT, envelope.ciphertext, output)?;
+
+    Ok(())
+}
+
+/// Encode a Ed25519 signature into CESR
+/// TODO: replace type with a more precise "signature" type
+pub fn encode_signature(signature: Signature, output: &mut impl for<'a> Extend<&'a u8>) {
+    encode_fixed_data(ED25519_SIGNATURE, signature, output);
+}
+
+/// Decode an encrypted TSP message plus Envelope & Signature
+pub fn decode_envelope<'a, Vid: From<&'a [u8]>>(
+    mut stream: &'a [u8],
+) -> Result<(Envelope<Vid>, Signature), DecodeError> {
+    let sender = decode_variable_data(TSP_DEVELOPMENT_VID, &mut stream)
+        .ok_or(DecodeError)?
+        .into();
+    let receiver = decode_variable_data(TSP_DEVELOPMENT_VID, &mut stream)
+        .ok_or(DecodeError)?
+        .into();
+    let nonconfidential_header = decode_variable_data(TSP_PLAINTEXT, &mut stream);
+    let ciphertext = decode_variable_data(TSP_CIPHERTEXT, &mut stream).ok_or(DecodeError)?;
+    let signature = decode_fixed_data(ED25519_SIGNATURE, &mut stream).ok_or(DecodeError)?;
+
+    Ok((
+        Envelope {
+            sender,
+            receiver,
+            nonconfidential_header,
+            ciphertext,
+        },
+        signature,
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn envelope_without_nonconfidential_header() {
+        fn dummy_crypt(data: &[u8]) -> &[u8] {
+            data
+        }
+        let fixed_sig = [1; 64];
+
+        let cesr_payload = {
+            let mut inner = vec![];
+            encode_payload(Payload::HpkeMessage(b"Hello TSP!"), &mut inner).unwrap();
+            inner
+        };
+
+        let mut outer = vec![];
+        encode_envelope(
+            Envelope {
+                sender: &b"Alister"[..],
+                receiver: &b"Bobbi"[..],
+                nonconfidential_header: None,
+                ciphertext: dummy_crypt(&cesr_payload),
+            },
+            &mut outer,
+        )
+        .unwrap();
+        encode_signature(&fixed_sig, &mut outer);
+
+        let (env, sig) = decode_envelope::<&[u8]>(&outer).unwrap();
+        assert_eq!(sig, &fixed_sig);
+        assert_eq!(env.sender, &b"Alister"[..]);
+        assert_eq!(env.receiver, &b"Bobbi"[..]);
+        assert_eq!(env.nonconfidential_header, None);
+
+        let Payload::HpkeMessage(data) = decode_payload(dummy_crypt(env.ciphertext)).unwrap();
+        assert_eq!(data, b"Hello TSP!");
+    }
+
+    #[test]
+    fn envelope_with_nonconfidential_header() {
+        fn dummy_crypt(data: &[u8]) -> &[u8] {
+            data
+        }
+        let fixed_sig = [1; 64];
+
+        let cesr_payload = {
+            let mut inner = vec![];
+            encode_payload(Payload::HpkeMessage(b"Hello TSP!"), &mut inner).unwrap();
+            inner
+        };
+
+        let mut outer = vec![];
+        encode_envelope(
+            Envelope {
+                sender: &b"Alister"[..],
+                receiver: &b"Bobbi"[..],
+                nonconfidential_header: Some(b"treasure"),
+                ciphertext: dummy_crypt(&cesr_payload),
+            },
+            &mut outer,
+        )
+        .unwrap();
+        encode_signature(&fixed_sig, &mut outer);
+
+        let (env, sig) = decode_envelope::<&[u8]>(&outer).unwrap();
+        assert_eq!(sig, &fixed_sig);
+        assert_eq!(env.sender, &b"Alister"[..]);
+        assert_eq!(env.receiver, &b"Bobbi"[..]);
+        assert_eq!(env.nonconfidential_header, Some(&b"treasure"[..]));
+
+        let Payload::HpkeMessage(data) = decode_payload(dummy_crypt(env.ciphertext)).unwrap();
+        assert_eq!(data, b"Hello TSP!");
+    }
+
+    #[test]
+    fn envelope_failure() {
+        let fixed_sig = [1; 64];
+
+        let mut outer = vec![];
+        encode_signature(&fixed_sig, &mut outer);
+        encode_envelope(
+            Envelope {
+                sender: &b"Alister"[..],
+                receiver: &b"Bobbi"[..],
+                nonconfidential_header: Some(b"treasure"),
+                ciphertext: &[],
+            },
+            &mut outer,
+        )
+        .unwrap();
+
+        assert!(decode_envelope::<&[u8]>(&outer).is_err());
+    }
+}

--- a/tsp-cesr/src/packet.rs
+++ b/tsp-cesr/src/packet.rs
@@ -102,6 +102,7 @@ pub fn encode_ciphertext(
 #[derive(Clone, Debug)]
 #[must_use]
 pub struct VerificationChallenge<'a> {
+    pub associated_data: &'a [u8],
     pub signed_data: &'a [u8],
     pub signature: &'a Signature,
 }
@@ -120,6 +121,8 @@ pub fn decode_envelope<'a, Vid: TryFrom<&'a [u8]>>(
         .try_into()
         .map_err(|_| DecodeError::VidError)?;
     let nonconfidential_header = decode_variable_data(TSP_PLAINTEXT, &mut stream);
+    let associated_data = &origin[..origin.len() - stream.len()];
+
     let ciphertext =
         decode_variable_data(TSP_CIPHERTEXT, &mut stream).ok_or(DecodeError::UnexpectedData)?;
     let signed_data = &origin[..origin.len() - stream.len()];
@@ -137,6 +140,7 @@ pub fn decode_envelope<'a, Vid: TryFrom<&'a [u8]>>(
             nonconfidential_header,
         },
         VerificationChallenge {
+            associated_data,
             signed_data,
             signature,
         },
@@ -217,6 +221,7 @@ pub fn decode_tsp_message<'a, Vid: TryFrom<&'a [u8]>>(
         VerificationChallenge {
             signed_data,
             signature,
+            ..
         },
         ciphertext,
     ) = decode_envelope(data)?;

--- a/tsp-crypto/Cargo.toml
+++ b/tsp-crypto/Cargo.toml
@@ -13,3 +13,4 @@ hpke = { workspace = true }
 rand = { workspace = true }
 ed25519-dalek = { workspace = true }
 crypto_box = { workspace = true }
+tsp-cesr = { path = "../tsp-cesr" }

--- a/tsp-crypto/src/lib.rs
+++ b/tsp-crypto/src/lib.rs
@@ -5,11 +5,12 @@ pub struct Message<'a> {
     pub sender: &'a [u8; 32],
     pub receiver: &'a [u8; 32],
     pub header: &'a [u8],
-    pub secret_message: &'a [u8],
+    pub secret_message: Vec<u8>,
 }
 
 impl Message<'_> {
-    pub fn serialize_header(&self) -> Vec<u8> {
+    #[allow(dead_code)]
+    fn serialize_header(&self) -> Vec<u8> {
         let mut result = Vec::<u8>::with_capacity(64);
 
         result
@@ -18,6 +19,22 @@ impl Message<'_> {
         result.write_all(self.sender).unwrap();
         result.write_all(self.receiver).unwrap();
         result.write_all(self.header).unwrap();
+
+        result
+    }
+
+    fn cesr_header(&self) -> Vec<u8> {
+        use tsp_cesr::*;
+        let mut result = Vec::with_capacity(64);
+        encode_envelope(
+            Envelope {
+                sender: self.sender,
+                receiver: self.receiver,
+                nonconfidential_header: Some(self.header),
+            },
+            &mut result,
+        )
+        .expect("error encoding the envelope");
 
         result
     }


### PR DESCRIPTION
This changes the in-place HPKE handling in the tsp-crypto POC back to non-in-place handling since that makes the codes slightly clearer. See PR #36 that undoes that change.