### PR TITLE
Add function to determine sender and receiver

### DIFF
--- a/tsp-cesr/src/lib.rs
+++ b/tsp-cesr/src/lib.rs
@@ -55,6 +55,16 @@ mod selector {
     pub const DASH: u32 = 62;
 }
 
+/// (Temporary) interface to get Sender/Receiver VID's information from a CESR-encoded message
+pub fn get_sender_receiver(stream: &mut [u8]) -> Result<(&[u8], &[u8]), error::DecodeError> {
+    let envelope = decode_envelope_mut(stream)?
+        .into_opened()
+        .expect("Infallible")
+        .envelope;
+
+    Ok((envelope.sender, envelope.receiver))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Note: for efficiency, it would be best to change the interface of HPKE `open` so it takes a `CipherView`, i.e. with all the CESR-info already pre-decoded; using the current function will cause CESR-decoding to happen twice.